### PR TITLE
adding pytest-xdist to recipe, so users can run nipype.test

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,7 @@ requirements:
     - funcsigs
     - configparser  # [py27 or py34]
     - pytest >=3.0
+    - pytest-xdist
     - mock
     - pydotplus
     - xvfbwrapper


### PR DESCRIPTION
closes a [nipype issue](https://github.com/nipy/nipype/issues/2645)